### PR TITLE
Refactor StateMachine and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ ExportedObj/
 *.pidb.meta
 *.pdb.meta
 *.mdb.meta
-*.cs.meta
 LICENSE.meta
 README.md.meta
 

--- a/Kuro.UnityUtils/DesignPatterns/EventBus.cs.meta
+++ b/Kuro.UnityUtils/DesignPatterns/EventBus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62040e7e4da0d514595c4dcf827bd39a

--- a/Kuro.UnityUtils/DesignPatterns/MonoStateMachine.cs.meta
+++ b/Kuro.UnityUtils/DesignPatterns/MonoStateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ba0c8dec87e9f1478833157a62a1e0e

--- a/Kuro.UnityUtils/DesignPatterns/Singleton.cs.meta
+++ b/Kuro.UnityUtils/DesignPatterns/Singleton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c707e5359fab1ff499bca3a86cf39a43

--- a/Kuro.UnityUtils/DesignPatterns/StateMachine.cs
+++ b/Kuro.UnityUtils/DesignPatterns/StateMachine.cs
@@ -1,52 +1,129 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Kuro.UnityUtils.DesignPatterns
 {
-    public interface IState<TOwner>
+    #region State Interfaces
+    public interface IStateEnter<TOwner>
     {
+<<<<<<< Updated upstream
         public void OnEnter(TOwner owner);
         public void OnExit(TOwner owner);
         public void OnDynamicStay(TOwner owner);
         public void OnFixedStay(TOwner owner);
+=======
+        void OnEnter(TOwner owner);
+>>>>>>> Stashed changes
     }
 
+    public interface IStateExit<TOwner>
+    {
+        void OnExit(TOwner owner);
+    }
+
+    public interface IStateUpdate<TOwner>
+    {
+        void OnUpdate(TOwner owner);
+    }
+
+    public interface IStateFixedUpdate<TOwner>
+    {
+        void OnFixedUpdate(TOwner owner);
+    }
+
+    public interface IState<TOwner> :
+        IStateEnter<TOwner>,
+        IStateExit<TOwner>,
+        IStateUpdate<TOwner>,
+        IStateFixedUpdate<TOwner>
+    { }
+
+    public readonly struct StateCache<TOwner>
+    {
+        public readonly object StateObject;
+        public readonly IStateEnter<TOwner> Enter;
+        public readonly IStateExit<TOwner> Exit;
+        public readonly IStateUpdate<TOwner> Update;
+        public readonly IStateFixedUpdate<TOwner> FixedUpdate;
+
+        public StateCache(object stateObject)
+        {
+            StateObject = stateObject ?? throw new ArgumentNullException(nameof(stateObject));
+            Enter = stateObject as IStateEnter<TOwner>;
+            Exit = stateObject as IStateExit<TOwner>;
+            Update = stateObject as IStateUpdate<TOwner>;
+            FixedUpdate = stateObject as IStateFixedUpdate<TOwner>;
+        }
+
+        public void OnEnter(TOwner owner) => Enter?.OnEnter(owner);
+        public void OnExit(TOwner owner) => Exit?.OnExit(owner);
+        public void OnUpdate(TOwner owner) => Update?.OnUpdate(owner);
+        public void OnFixedUpdate(TOwner owner) => FixedUpdate?.OnFixedUpdate(owner);
+    }
+    #endregion
+
+    #region StateMachine Core
     public class StateMachine<TOwner>
     {
-        public delegate void StateChangedHandler(IState<TOwner> previousState, IState<TOwner> newState);
+        public delegate void StateChangedHandler(object previousState, object newState);
         public event StateChangedHandler OnStateChanged;
 
-        public IState<TOwner> CurrentState => _currentState;
-        public IReadOnlyDictionary<Type, IState<TOwner>> States => _states;
+        public object CurrentState => _currentState.StateObject;
 
         private readonly TOwner _owner;
-        private IState<TOwner> _currentState;
-        private readonly Dictionary<Type, IState<TOwner>> _states = new();
+        private StateCache<TOwner> _currentState;
+        private readonly Dictionary<Type, StateCache<TOwner>> _states = new();
 
         public StateMachine(TOwner owner) => _owner = owner ?? throw new ArgumentNullException(nameof(owner));
 
-        public void AddState<TState>(TState state) where TState : IState<TOwner>
-            => _states[typeof(TState)] = state ?? throw new ArgumentNullException(nameof(state));
-
-        public virtual void ChangeState<TState>(TState state = default) where TState : IState<TOwner>
+        public StateMachine<TOwner> Add<TState>(TState state) where TState : new()
         {
-            _currentState?.OnExit(_owner);
+            if (!IsValidState(typeof(TState)))
+                throw new Exception($"State {typeof(TState)} does not implement required interfaces.");
 
-            if (_states.TryGetValue(typeof(TState), out var newState))
-            {
-                var previousState = _currentState;
-                _currentState = newState;
-                _currentState?.OnEnter(_owner);
+            if (_states.ContainsKey(typeof(TState)))
+                throw new Exception($"State {typeof(TState)} already exists in FSM.");
 
-                OnStateChanged?.Invoke(previousState, _currentState);
-            }
-            else
-            {
-                throw new Exception($"State {typeof(TState)} not found in FSM.");
-            }
+            var stateCache = new StateCache<TOwner>(state);
+            _states.Add(typeof(TState), stateCache);
+
+            return this;
         }
 
+<<<<<<< Updated upstream
         public void DynamicStay() => _currentState?.OnDynamicStay(_owner);
         public void FixedStay() => _currentState?.OnFixedStay(_owner);
+=======
+        public virtual void ChangeState<TState>(TState state = default)
+        {
+            if (!IsValidState(typeof(TState)))
+                throw new Exception($"State {typeof(TState)} does not implement required interfaces.");
+
+            if (!_states.TryGetValue(typeof(TState), out var newState))
+                throw new Exception($"State {typeof(TState)} not found in FSM.");
+
+            if (_currentState.StateObject != null)
+                _currentState.OnExit(_owner);
+
+            var previousState = _currentState.StateObject;
+            _currentState = newState;
+            _currentState.OnEnter(_owner);
+
+            OnStateChanged?.Invoke(previousState, _currentState.StateObject);
+        }
+
+        public void DynamicStay() => _currentState.OnUpdate(_owner);
+        public void FixedStay() => _currentState.OnFixedUpdate(_owner);
+
+        private bool IsValidState(Type stateType) =>
+            stateType.GetInterfaces().Any(i =>
+                i == typeof(IStateEnter<TOwner>) ||
+                i == typeof(IStateExit<TOwner>) ||
+                i == typeof(IStateUpdate<TOwner>) ||
+                i == typeof(IStateFixedUpdate<TOwner>) ||
+                i == typeof(IState<TOwner>));
+>>>>>>> Stashed changes
     }
+    #endregion
 }

--- a/Kuro.UnityUtils/DesignPatterns/StateMachine.cs.meta
+++ b/Kuro.UnityUtils/DesignPatterns/StateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 302f6a60950696741849e5694689b162

--- a/Kuro.UnityUtils/Services/FileConverterService.cs.meta
+++ b/Kuro.UnityUtils/Services/FileConverterService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c9c11abc021465246a413f73ace2e611

--- a/Kuro.UnityUtils/Services/FileLoaderService.cs.meta
+++ b/Kuro.UnityUtils/Services/FileLoaderService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5e94ead53107e447ae4841b7426b867

--- a/Kuro.UnityUtils/Services/LoaderTester.cs.meta
+++ b/Kuro.UnityUtils/Services/LoaderTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 328c9d997d9a44744860a798ce1f74d2

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fcf97b0ebbbc52e4ca9b73e6a062e16f
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Refactored StateMachine to use new state interfaces and a StateCache struct for improved flexibility and type safety. Updated .gitignore to stop ignoring .cs.meta files. Added .meta files for new and existing scripts, and removed the obsolete Tests.meta file.